### PR TITLE
Fixed regexp to work on returned values and arrays/maps/slices

### DIFF
--- a/rplugin/python3/deoplete/sources/go.py
+++ b/rplugin/python3/deoplete/sources/go.py
@@ -25,7 +25,7 @@ class Source(Base):
         self.name = 'go'
         self.mark = '[go]'
         self.filetypes = ['go']
-        self.input_pattern = r'[a-zA-Z_]\w*\.\w*'
+        self.input_pattern = r'\(\([a-zA-Z_]\w*\)|[\])]\)\.\w*'
         self.rank = 500
 
         self.align_class = self.vim.vars['deoplete#sources#go#align_class']


### PR DESCRIPTION
For example the following file (`|` is cursor)

``` go
package main

import (
    "net/http"
)

func main() {
    http.FileServer().|
}
```

also added `]` to make it work with maps/arrays.
