### PR TITLE
use static json cache even if package is imported

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_go.py
+++ b/rplugin/python3/deoplete/sources/deoplete_go.py
@@ -188,8 +188,7 @@ class Source(Base):
         current_import = self.parse_import_package(buffer)
         import_package = [x['package'] for x in current_import]
 
-        if package == '' or package in import_package \
-                or package not in stdlib.packages:
+        if package == '' or package not in stdlib.packages:
             return None
 
         library = stdlib.packages.get(package)


### PR DESCRIPTION
It is significantly faster on my Macbook Pro to always use the json cache even if the package is imported.
