### PR TITLE
Automatic GOOS option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,9 +321,9 @@ If not set, deoplete-go use `c11`(latest) version.
 | **Example**  | `1`     |
 
 When enabled, deoplete-go will try to set `GOOS` by checking the file name for
-`name_<OS>.go`.  If not found, the first 10 lines will be checked for first `//
-+build <OS>` directive.  If the file's OS doesn't match your OS (e.g.
-`file_darwin.go` while on `linux`), `CGO_ENABLED=0` will also be set.
+`name_<OS>.go`.  If not found, the file will be checked for a `// +build <OS>`
+directive.  If the file's OS doesn't match your OS (e.g.  `file_darwin.go`
+while on `linux`), `CGO_ENABLED=0` will also be set.
 
 **Note:** There may be a 5-10 second delay if `gocode` needs to compile the
 platform-specific sources for the first time.

--- a/README.md
+++ b/README.md
@@ -311,25 +311,21 @@ In darwin, `libclang.dylib`, In Linux, `libclang.so`.
 C language standard version option.  
 If not set, deoplete-go use `c11`(latest) version.
 
-### `g:deoplete#sources#go#goos`
-#### Set GOOS environment variable when calling `gocode`
+### `g:deoplete#sources#go#auto_goos`
+#### Automatically set GOOS environment variable when calling `gocode`
 
-| **Default**  | `''`      |
-|--------------|-----------|
-| **Required** | No        |
-| **Type**     | string    |
-| **Example**  | `windows` |
+| **Default**  | `0`     |
+|--------------|---------|
+| **Required** | No      |
+| **Type**     | boolean |
+| **Example**  | `1`     |
 
-Sets the `GOOS` environment variable for `gocode`.  Set it to `auto` if you
-want `GOOS` to be automatically set depending on the current buffer's file.
-
-When set to `auto`, deoplete-go will try to set `GOOS` by checking the file
-name for `name_<OS>.go`.  If not found, the first 10 lines will be checked for
-first `// +build <OS>` directive.  If the file's OS doesn't match your OS (e.g.
+When enabled, deoplete-go will try to set `GOOS` by checking the file name for
+`name_<OS>.go`.  If not found, the first 10 lines will be checked for first `//
++build <OS>` directive.  If the file's OS doesn't match your OS (e.g.
 `file_darwin.go` while on `linux`), `CGO_ENABLED=0` will also be set.
 
-**Note:** You may need to run `gocode close` for this to take effect.
-Additionally, there may be a 5-10 second delay if `gocode` needs to compile the
+**Note:** There may be a 5-10 second delay if `gocode` needs to compile the
 platform-specific sources for the first time.
 
 ===

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Plug 'zchee/deoplete-go', { 'do': 'make'}
 | `g:deoplete#sources#go#use_cache`      | `0`     | **Recommend** |
 | `g:deoplete#sources#go#json_directory` | `''`    | **Recommend** |
 | `g:deoplete#sources#go#cgo`            | `0`     | *Any*         |
+| `g:deoplete#sources#go#goos`           | `''`    | No            |
 
 ### `g:deoplete#sources#go#gocode_binary`
 #### `gocode` Binary
@@ -309,6 +310,27 @@ In darwin, `libclang.dylib`, In Linux, `libclang.so`.
 
 C language standard version option.  
 If not set, deoplete-go use `c11`(latest) version.
+
+### `g:deoplete#sources#go#goos`
+#### Set GOOS environment variable when calling `gocode`
+
+| **Default**  | `''`      |
+|--------------|-----------|
+| **Required** | No        |
+| **Type**     | string    |
+| **Example**  | `windows` |
+
+Sets the `GOOS` environment variable for `gocode`.  Set it to `auto` if you
+want `GOOS` to be automatically set depending on the current buffer's file.
+
+When set to `auto`, deoplete-go will try to set `GOOS` by checking the file
+name for `name_<OS>.go`.  If not found, the first 10 lines will be checked for
+first `// +build <OS>` directive.  If the file's OS doesn't match your OS (e.g.
+`file_darwin.go` while on `linux`), `CGO_ENABLED=0` will also be set.
+
+**Note:** You may need to run `gocode close` for this to take effect.
+Additionally, there may be a 5-10 second delay if `gocode` needs to compile the
+platform-specific sources for the first time.
 
 ===
 

--- a/rplugin/python3/deoplete/sources/deoplete_go.py
+++ b/rplugin/python3/deoplete/sources/deoplete_go.py
@@ -225,8 +225,10 @@ class Source(Base):
                         env['GOOS'] = part
                         break
             if 'GOOS' not in env:
-                for line in buffer[:10]:
-                    if not line.startswith('// +build'):
+                for line in buffer:
+                    if line.startswith('package '):
+                        break
+                    elif not line.startswith('// +build'):
                         continue
                     for item in line[9:].strip().split():
                         item = item.split(',', 1)[0]

--- a/rplugin/python3/deoplete/sources/deoplete_go.py
+++ b/rplugin/python3/deoplete/sources/deoplete_go.py
@@ -230,11 +230,13 @@ class Source(Base):
                         break
                     elif not line.startswith('// +build'):
                         continue
-                    for item in line[9:].strip().split():
-                        item = item.split(',', 1)[0]
-                        if item in known_goos:
-                            env['GOOS'] = item
-                            break
+                    directives = [x.split(',', 1)[0]
+                                  for x in line[9:].strip().split()]
+                    if platform.system().lower() not in directives:
+                        for plat in directives:
+                            if plat in known_goos:
+                                env['GOOS'] = plat
+                                break
         elif self.goos != '':
             env['GOOS'] = self.goos
 

--- a/rplugin/python3/deoplete/sources/deoplete_go.py
+++ b/rplugin/python3/deoplete/sources/deoplete_go.py
@@ -1,5 +1,6 @@
 import os
 import re
+import platform
 import subprocess
 
 from collections import OrderedDict
@@ -16,6 +17,20 @@ try:
     from ujson import loads
 except ImportError:
     from json import loads
+
+known_goos = (
+    'android',
+    'darwin',
+    'dragonfly',
+    'freebsd',
+    'linux',
+    'nacl',
+    'netbsd',
+    'openbsd',
+    'plan9',
+    'solaris',
+    'windows'
+)
 
 
 class Source(Base):
@@ -44,7 +59,6 @@ class Source(Base):
             vars.get('deoplete#sources#go#json_directory', '')
         self.use_on_event = vars.get('deoplete#sources#go#on_event', False)
         self.cgo = vars.get('deoplete#sources#go#cgo', False)
-        self.debug_enabled = vars.get('deoplete#sources#go#debug', False)
 
         self.complete_pos = re.compile(r'\w*$|(?<=")[./\-\w]*$')
 
@@ -200,23 +214,43 @@ class Source(Base):
         offset = self.vim.call('line2byte', line) + \
             charpos2bytepos('utf-8', context['input'][: column],
                             column) - 1
-        source = '\n'.join(buffer).encode()
 
         env = os.environ.copy()
         if self.goos != '':
-            env['GOOS'] = self.goos
+            if self.goos == 'auto':
+                name = os.path.basename(os.path.splitext(buffer.name)[0])
+                if '_' in name:
+                    for part in name.rsplit('_', 2):
+                        if part in known_goos:
+                            env['GOOS'] = part
+                            break
+                if 'GOOS' not in env:
+                    for line in buffer[:10]:
+                        if not line.startswith('// +build'):
+                            continue
+                        for item in line[9:].strip().split():
+                            item = item.split(',', 1)[0]
+                            if item in known_goos:
+                                env['GOOS'] = item
+                                break
+            else:
+                env['GOOS'] = self.goos
+
+            if 'GOOS' in env and env['GOOS'] != platform.system().lower():
+                env['CGO_ENABLED'] = '0'
         if self.goarch != '':
             env['GOARCH'] = self.goarch
+
         process = subprocess.Popen(
-            [self.find_gocode_binary(), '-f=json', 'autocomplete', buffer.name,
+            [self.find_gocode_binary(), '-debug', '-f=json', 'autocomplete', buffer.name,
              str(offset)],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             start_new_session=True,
             env=env)
-        process.stdin.write(source)
-        stdout_data, stderr_data = process.communicate()
+        stdout_data, stderr_data = process.communicate('\n'.join(buffer).encode())
+
         if kwargs and kwargs['kill'] is True:
             process.kill
         return loads(stdout_data.decode())


### PR DESCRIPTION
This allows for `GOOS` to be automatically set.  Screen shots from a Linux computer without restarting Neovim or setting the environment manually:

Windows:

![screen-shot-2016-10-02-13-38-59](https://cloud.githubusercontent.com/assets/111942/19022389/c4c6f8b0-88a5-11e6-95aa-95a6832a3f1f.png)

![screen-shot-2016-10-02-13-41-02](https://cloud.githubusercontent.com/assets/111942/19022393/e4627e6a-88a5-11e6-88a0-eec58b097eef.png)

![screen-shot-2016-10-02-13-41-39](https://cloud.githubusercontent.com/assets/111942/19022398/f9b946c2-88a5-11e6-8052-ff79410c867f.png)

Darwin:

![screen-shot-2016-10-02-13-45-51](https://cloud.githubusercontent.com/assets/111942/19022426/97aa5d80-88a6-11e6-91b9-86613b0ed1f0.png)

![screen-shot-2016-10-02-13-59-49](https://cloud.githubusercontent.com/assets/111942/19022536/8fc12a84-88a8-11e6-92ee-717bfc87f558.png)

![screen-shot-2016-10-02-14-03-10](https://cloud.githubusercontent.com/assets/111942/19022565/ff59dc42-88a8-11e6-96b3-46175ebe5501.png)

FreeBSD:

![screen-shot-2016-10-02-13-47-04](https://cloud.githubusercontent.com/assets/111942/19022429/bd0a0ce2-88a6-11e6-978d-c48ae761d368.png)

![screen-shot-2016-10-02-13-54-10](https://cloud.githubusercontent.com/assets/111942/19022495/cd7ba936-88a7-11e6-9343-13157662dede.png)
