### PR TITLE
Makefile: .PHONY targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,4 +75,4 @@ lint/install_modules:
 clean:
 	$(RM) -r $(CURRENT)/build $(TARGET) rplugin/python3/deoplete/ujson/build data/stdlib-$(GO_VERSION)_$(GOOS)_$(GOARCH).txt
 
-.PHONY: test lint clean build
+.PHONY: test lint clean gen_json build

--- a/Makefile
+++ b/Makefile
@@ -75,4 +75,4 @@ lint/install_modules:
 clean:
 	$(RM) -r $(CURRENT)/build $(TARGET) rplugin/python3/deoplete/ujson/build data/stdlib-$(GO_VERSION)_$(GOOS)_$(GOARCH).txt
 
-.PHONY: test lint clean
+.PHONY: test lint clean build


### PR DESCRIPTION
The install method mentioned in the README
```
Plug 'zchee/deoplete-go', { 'do': 'make'}
```
errored a couple of times for me already. As seen here:
```
% cd ~/.local/share/nvim/plugins/deoplete-go                           :(
rvolosatovs@atom ~/.local/share/nvim/plugins/deoplete-go (git)-[master] % ls
benchmark  build  data  Dockerfile  images  LICENSE  Makefile  plugin  README.md  rplugin  tests
rvolosatovs@atom ~/.local/share/nvim/plugins/deoplete-go (git)-[master] % make
mv  /home/rvolosatovs/.local/share/nvim/plugins/deoplete-go/rplugin/python3/deoplete/ujson.so
mv: missing destination file operand after '/home/rvolosatovs/.local/share/nvim/plugins/deoplete-go/rplugin/python3/deoplete/ujson.so'
Try 'mv --help' for more information.
make: *** [Makefile:38: /home/rvolosatovs/.local/share/nvim/plugins/deoplete-go/rplugin/python3/deoplete/ujson.so] Error 1
```

Adding `build` to .PHONY fixes the issue. I also added `gen_json` along the way.