### PR TITLE
Don't attempt to re-raise when there wasn't an Exception.

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_go.py
+++ b/rplugin/python3/deoplete/sources/deoplete_go.py
@@ -284,11 +284,8 @@ class Source(Base):
             return self.gocode_binary
 
         try:
-            if os.path.isfile(self.gocode_binary):
-                self.loaded_gocode_binary = True
-                return self.gocode_binary
-            else:
-                raise
+            self.loaded_gocode_binary = os.path.isfile(self.gocode_binary)
+            return self.gocode_binary
         except Exception:
             if platform.system().lower() == 'windows':
                 return self.find_binary_path('gocode.exe')


### PR DESCRIPTION
Vim was yeling at me. Ends up this code was attempting to raise outside of an exception. T

The deleted code can never execute successfully, since an exception existing would cause the `except Exception` block to execute instead of the `else` block.