### PR TITLE
Support completing built-in objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,15 @@ Plug 'zchee/deoplete-go', { 'do': 'make'}
 
 ## Available Settings
 
-| Setting value                          | Default | Required      |
-|:---------------------------------------|:-------:|:-------------:|
-| `g:deoplete#sources#go#gocode_binary`  | `''`    | **Recommend** |
-| `g:deoplete#sources#go#package_dot`    | `0`     | No            |
-| `g:deoplete#sources#go#sort_class`     | `[]`    | **Recommend** |
-| `g:deoplete#sources#go#cgo`            | `0`     | *Any*         |
-| `g:deoplete#sources#go#goos`           | `''`    | No            |
-| `g:deoplete#sources#go#source_importer`| `0`     | No            |
+| Setting value                           | Default | Required      |
+|:---------------------------------------:|:-------:|:-------------:|
+| `g:deoplete#sources#go#gocode_binary`   | `''`    | **Recommend** |
+| `g:deoplete#sources#go#package_dot`     | `0`     | No            |
+| `g:deoplete#sources#go#sort_class`      | `[]`    | **Recommend** |
+| `g:deoplete#sources#go#cgo`             | `0`     | *Any*         |
+| `g:deoplete#sources#go#goos`            | `''`    | No            |
+| `g:deoplete#sources#go#source_importer` | `0`     | No            |
+| `g:deoplete#sources#go#builtin_objects` | `0`     | No            |
 
 ### `g:deoplete#sources#go#gocode_binary`
 #### `gocode` Binary
@@ -296,6 +297,17 @@ When enabled, deoplete-go can complete external packages.
 Note: It is for "mdempsky/gocode" only option.  And if it is enabled, the
 completion is slower.
 https://github.com/mdempsky/gocode
+
+### `g:deoplete#sources#go#builtin_objects`
+#### Propose builtin objects
+
+| **Default**  | `0` |
+|--------------|-----|
+| **Required** | No  |
+| **Type**     | int |
+| **Example**  | `1` |
+
+When enabled, deoplete-go can complete builtin objects.
 
 ---
 

--- a/rplugin/python3/deoplete/sources/deoplete_go.py
+++ b/rplugin/python3/deoplete/sources/deoplete_go.py
@@ -57,6 +57,8 @@ class Source(Base):
             vars.get('deoplete#sources#go#cgo', False)
         self.source_importer = \
             vars.get('deoplete#sources#go#source_importer', False)
+        self.builtin_objects = \
+            vars.get('deoplete#sources#go#builtin_objects', False)
 
         self.loaded_gocode_binary = False
         self.complete_pos = re.compile(r'\w*$|(?<=")[./\-\w]*$')
@@ -214,6 +216,8 @@ class Source(Base):
         args = [gocode, '-f=json']
         if self.source_importer:
             args.append('-source')
+        if self.builtin_objects:
+            args.append('-builtin')
         # basically, '-sock' option for mdempsky/gocode.
         # probably meaningless in nsf/gocode that already run the rpc server
         if self.sock != '' and self.sock in ['unix', 'tcp', 'none']:


### PR DESCRIPTION
Introduced in https://github.com/mdempsky/gocode/commit/9f6c12218c306acb79904362833755c25464b778

When enabled, completions for built-in types like `string` will be available. For example:

![example completion of `string`](https://user-images.githubusercontent.com/395621/46184369-5b2e0300-c2a3-11e8-9069-d322321851bb.png)
