### PR TITLE
Add support for completing unimported packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,16 @@ Plug 'zchee/deoplete-go', { 'do': 'make'}
 
 ## Available Settings
 
-| Setting value                           | Default | Required      |
-|:---------------------------------------:|:-------:|:-------------:|
-| `g:deoplete#sources#go#gocode_binary`   | `''`    | **Recommend** |
-| `g:deoplete#sources#go#package_dot`     | `0`     | No            |
-| `g:deoplete#sources#go#sort_class`      | `[]`    | **Recommend** |
-| `g:deoplete#sources#go#cgo`             | `0`     | *Any*         |
-| `g:deoplete#sources#go#goos`            | `''`    | No            |
-| `g:deoplete#sources#go#source_importer` | `0`     | No            |
-| `g:deoplete#sources#go#builtin_objects` | `0`     | No            |
+| Setting value                               | Default | Required      |
+|:---------------------------------------:    |:-------:|:-------------:|
+| `g:deoplete#sources#go#gocode_binary`       | `''`    | **Recommend** |
+| `g:deoplete#sources#go#package_dot`         | `0`     | No            |
+| `g:deoplete#sources#go#sort_class`          | `[]`    | **Recommend** |
+| `g:deoplete#sources#go#cgo`                 | `0`     | *Any*         |
+| `g:deoplete#sources#go#goos`                | `''`    | No            |
+| `g:deoplete#sources#go#source_importer`     | `0`     | No            |
+| `g:deoplete#sources#go#builtin_objects`     | `0`     | No            |
+| `g:deoplete#sources#go#unimported_packages` | `0`     | No            |
 
 ### `g:deoplete#sources#go#gocode_binary`
 #### `gocode` Binary
@@ -311,6 +312,18 @@ https://github.com/mdempsky/gocode/pull/71
 | **Example**  | `1` |
 
 When enabled, deoplete-go can complete builtin objects.
+
+### `g:deoplete#sources#go#unimported_packages`
+#### Propose completions for unimported standard library packages
+
+| **Default**  | `0` |
+|--------------|-----|
+| **Required** | No  |
+| **Type**     | int |
+| **Example**  | `1` |
+
+When enabled, deoplete-go can complete standard library packages that are
+not explicitely imported yet.
 
 ---
 

--- a/rplugin/python3/deoplete/sources/deoplete_go.py
+++ b/rplugin/python3/deoplete/sources/deoplete_go.py
@@ -59,6 +59,8 @@ class Source(Base):
             vars.get('deoplete#sources#go#source_importer', False)
         self.builtin_objects = \
             vars.get('deoplete#sources#go#builtin_objects', False)
+        self.unimported_packages = \
+            vars.get('deoplete#sources#go#unimported_packages', False)
 
         self.loaded_gocode_binary = False
         self.complete_pos = re.compile(r'\w*$|(?<=")[./\-\w]*$')
@@ -218,6 +220,8 @@ class Source(Base):
             args.append('-source')
         if self.builtin_objects:
             args.append('-builtin')
+        if self.unimported_packages:
+            args.append('-unimported-packages')
         # basically, '-sock' option for mdempsky/gocode.
         # probably meaningless in nsf/gocode that already run the rpc server
         if self.sock != '' and self.sock in ['unix', 'tcp', 'none']:


### PR DESCRIPTION
This feature works really well with `mdempsky/gocode`, so I would love to be able to enable it using `deoplete-go`